### PR TITLE
Controller name customization

### DIFF
--- a/Include/Xidi/Internal/Strings.h
+++ b/Include/Xidi/Internal/Strings.h
@@ -97,8 +97,14 @@ namespace Xidi
     /// Configuration file section name for mapper-related settings.
     inline constexpr std::wstring_view kStrConfigurationSectionMapper = L"Mapper";
 
+    /// Configuration file section name for controller names.
+    inline constexpr std::wstring_view kStrConfigurationSectionNames = L"Names";
+
     /// Configuration file setting for specifying the mapper type.
     inline constexpr std::wstring_view kStrConfigurationSettingMapperType = L"Type";
+
+    /// Configuration file setting for specifying the controller name.
+    inline constexpr std::wstring_view kStrConfigurationSettingName = L"Name";
 
     /// Prefix for configuration file sections that define custom mappers.
     inline constexpr std::wstring_view kStrConfigurationSectionCustomMapperPrefix = L"CustomMapper";
@@ -283,6 +289,15 @@ namespace Xidi
     /// @return Corresponding configuration setting string, or an empty view if the controller
     /// identifier is out of range.
     std::wstring_view MapperTypeConfigurationNameString(
+        Controller::TControllerIdentifier controllerIdentifier);
+
+    /// Retrieves a string used to represent a per-controller name configuration setting.
+    /// These are initialized on first invocation and returned subsequently as read-only views.
+    /// An empty view is returned if an invalid controller identifier is specified.
+    /// @param [in] controllerIdentifier Controller identifier for which a name is desired.
+    /// @return Corresponding configuration setting string, or an empty view if the controller
+    /// identifier is out of range.
+    std::wstring_view NameConfigurationNameString(
         Controller::TControllerIdentifier controllerIdentifier);
 
     /// Splits a string using the specified delimiter string and returns a list of views each

--- a/Source/ControllerIdentification.cpp
+++ b/Source/ControllerIdentification.cpp
@@ -397,10 +397,29 @@ namespace Xidi
     instanceInfo.guidInstance = VirtualControllerGuid(controllerId);
     instanceInfo.guidProduct = VirtualControllerGuid(controllerId);
     instanceInfo.dwDevType = DINPUT_DEVTYPE_XINPUT_GAMEPAD;
-    FillVirtualControllerName(
-        instanceInfo.tszInstanceName, _countof(instanceInfo.tszInstanceName), controllerId);
-    FillVirtualControllerName(
-        instanceInfo.tszProductName, _countof(instanceInfo.tszProductName), controllerId);
+
+    FillVirtualControllerName(instanceInfo.tszInstanceName, _countof(instanceInfo.tszInstanceName), controllerId);
+    FillVirtualControllerName(instanceInfo.tszProductName, _countof(instanceInfo.tszProductName), controllerId);
+
+    const Configuration::ConfigurationData& configData = Globals::GetConfigurationData();
+
+    if(configData.SectionExists(Xidi::Strings::kStrConfigurationSectionNames))
+    {
+        TemporaryString perControllerNameString;
+        
+        perControllerNameString.Clear();
+        perControllerNameString << Xidi::Strings::kStrConfigurationSettingName << Xidi::Strings::kCharConfigurationSettingSeparator << (1 + controllerId);
+
+        const auto& controllerNameSection = configData[Xidi::Strings::kStrConfigurationSectionNames];
+        std::wstring_view controllerName = controllerNameSection[perControllerNameString].FirstValue().GetStringValue();
+        if (true == controllerNameSection.NameExists(Strings::NameConfigurationNameString(controllerId))) {
+            char finalControllerName[MAX_PATH];
+            sprintf_s(finalControllerName, MAX_PATH, "%ws", controllerName.data());
+            
+            sprintf_s((LPSTR)instanceInfo.tszProductName, MAX_PATH, finalControllerName);
+            sprintf_s((LPSTR)instanceInfo.tszInstanceName, MAX_PATH, finalControllerName);
+        }
+    }
 
     // DirectInput versions 5 and higher include extra members in this structure, and this is
     // indicated on input using the size member of the structure.

--- a/Source/Strings.cpp
+++ b/Source/Strings.cpp
@@ -544,6 +544,27 @@ namespace Xidi
       return initStrings[controllerIdentifier];
     }
 
+    std::wstring_view NameConfigurationNameString(
+        Controller::TControllerIdentifier controllerIdentifier)
+    {
+      static std::wstring initStrings[Controller::kPhysicalControllerCount];
+      static std::once_flag initFlag;
+
+      
+      TemporaryString perControllerNameString;
+
+      for (Controller::TControllerIdentifier i = 0; i < _countof(initStrings); ++i)
+      {
+          perControllerNameString.Clear();
+          perControllerNameString << kStrConfigurationSettingName << kCharConfigurationSettingSeparator << (1 + i);
+          initStrings[i] = perControllerNameString;
+      }
+
+      if (controllerIdentifier >= Controller::kPhysicalControllerCount) return std::wstring_view();
+
+      return initStrings[controllerIdentifier];
+    }
+
     TemporaryVector<std::wstring_view> SplitString(
         std::wstring_view stringToSplit, std::wstring_view delimiter)
     {

--- a/Source/XidiConfigReader.cpp
+++ b/Source/XidiConfigReader.cpp
@@ -126,6 +126,12 @@ namespace Xidi
                   Strings::kStrConfigurationSettingsWorkaroundsIgnoreEnumObjectsCallbackReturnCode,
                   EValueType::Boolean),
           }),
+      ConfigurationFileLayoutSection(
+          Strings::kStrConfigurationSectionNames,
+          {
+              ConfigurationFileLayoutNameAndValueType(
+                  Strings::kStrConfigurationSettingName, EValueType::String),
+          }),
   };
 
 #ifndef XIDI_SKIP_MAPPERS
@@ -375,14 +381,19 @@ namespace Xidi
         initFlag,
         []() -> void
         {
-          // Create the per-controller mapper settings types and submit them to the configuration
+          // Create the per-controller mapper and name settings types and submit them to the configuration
           // file layout. These are gernerated dynamically based on the number of controllers the
           // system supports.
           for (Controller::TControllerIdentifier i = 0; i < Controller::kPhysicalControllerCount;
-               ++i)
+               ++i) {
             configurationFileLayout[Strings::kStrConfigurationSectionMapper]
                                    [Strings::MapperTypeConfigurationNameString(i)] =
                                        EValueType::String;
+
+            configurationFileLayout[Strings::kStrConfigurationSectionNames]
+                                   [Strings::NameConfigurationNameString(i)] =
+                                       EValueType::String;
+            }
         });
   }
 


### PR DESCRIPTION
Some games cut off the device names in controls bindings screens so it makes it impossible to distinguish which controller is being interacted with.
For example "Xidi Virtual Controller 1" becomes "Xidi Virtual Contro..."

This change adds a new section to the .ini file to allow for controller name customizations.
```
[Names]
Name.1 = Controller 1
Name.2 = Controller 2
Name.3 = Controller 3
Name.4 = Controller 4
```