### PR TITLE
 Convert from SDL3 Gamepad rather than XInput 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Infra"]
 	path = Modules/Infra
 	url = https://github.com/samuelgr/Infra.git
+[submodule "ThirdParty/SDL3"]
+	path = ThirdParty/SDL3
+	url = https://github.com/libsdl-org/SDL

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = Modules/Infra
 	url = https://github.com/samuelgr/Infra.git
 [submodule "ThirdParty/SDL3"]
-	path = ThirdParty/SDL3
+	path = ThirdParty/SDL3/Files
 	url = https://github.com/libsdl-org/SDL

--- a/DInput.vcxproj
+++ b/DInput.vcxproj
@@ -103,7 +103,7 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
-    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+    <ProjectReference Include="ThirdParty\SDL3\SDL.vcxproj">
       <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/DInput.vcxproj
+++ b/DInput.vcxproj
@@ -103,6 +103,9 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
+    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+      <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{34FEDC3E-3FE8-43D0-9BDE-1A15332D8C41}</ProjectGuid>

--- a/DInput8.vcxproj
+++ b/DInput8.vcxproj
@@ -103,7 +103,7 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
-    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+    <ProjectReference Include="ThirdParty\SDL3\SDL.vcxproj">
       <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/DInput8.vcxproj
+++ b/DInput8.vcxproj
@@ -103,6 +103,9 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
+    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+      <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{023441F6-2554-440F-9FFB-7E185AB7CF41}</ProjectGuid>

--- a/Include/Xidi/Internal/ControllerIdentification.h
+++ b/Include/Xidi/Internal/ControllerIdentification.h
@@ -89,7 +89,7 @@ namespace Xidi
   /// @param [out] devicePath If present, will be filled with the device identifying path, which was
   /// used to determine whether or not the controller supports XInput.
   /// @return `true` if the controller supports XInput, `false` otherwise.
-  template <EDirectInputVersion diVersion> bool DoesDirectInputControllerSupportXInput(
+  template <EDirectInputVersion diVersion> bool DoesDirectInputControllerSupportSdlGamepad(
       typename DirectInputTypes<diVersion>::IDirectInputCompatType* dicontext,
       REFGUID instanceGUID,
       std::wstring* devicePath = nullptr);

--- a/Include/Xidi/Internal/ControllerMath.h
+++ b/Include/Xidi/Internal/ControllerMath.h
@@ -37,7 +37,7 @@ namespace Xidi
 
       /// Threshold value used to determine if a trigger is considered "pressed" or not as a digital
       /// button.
-      inline constexpr uint8_t kTriggerPressedThreshold = (kTriggerValueMax - kTriggerValueMin) / 6;
+      inline constexpr int16_t kTriggerPressedThreshold = (kTriggerValueMax - kTriggerValueMin) / 6;
 
       /// Threshold negative direction value used to determine if an analog stick is considered
       /// "pressed" or not as a digital button.
@@ -60,8 +60,8 @@ namespace Xidi
       /// @param [in] analogValue Analog value for which a deadzone should be applied.
       /// @param [in] deadzoneHudnredthsOfPercent Hundredths of a percent of the analog range for
       /// which the deadzone should be applied.
-      uint8_t ApplyRawTriggerTransform(
-          uint8_t triggerValue, unsigned int deadzonePercent, unsigned int saturationPercent);
+      int16_t ApplyRawTriggerTransform(
+          int16_t triggerValue, unsigned int deadzonePercent, unsigned int saturationPercent);
 
       /// Determines if an analog reading is considered "pressed" as a digital button in the
       /// negative direction.
@@ -92,7 +92,7 @@ namespace Xidi
       /// Determines if a trigger reading is considered "pressed" as a digital button.
       /// @param [in] triggerValue Trigger reading from the XInput controller.
       /// @return `true` if the virtual button is considered pressed, `false` otherwise.
-      constexpr bool IsTriggerPressed(uint8_t triggerValue)
+      constexpr bool IsTriggerPressed(int16_t triggerValue)
       {
         return (triggerValue >= kTriggerPressedThreshold);
       }

--- a/Include/Xidi/Internal/ControllerTypes.h
+++ b/Include/Xidi/Internal/ControllerTypes.h
@@ -21,10 +21,10 @@ namespace Xidi
 {
   namespace Controller
   {
-    /// Number of physical controllers that the underlying system supports.
+    /// Number of physical controllers currently supported by Xidi.
     /// Not all will necessarily be physically present at any given time.
     /// Maximum allowable controller identifier is one less than this value.
-    inline constexpr uint16_t kPhysicalControllerCount = 4;
+    inline constexpr int32_t kPhysicalControllerCount = 4;
 
     /// Maximum possible reading from an XInput controller's analog stick.
     /// Value taken from XInput documentation.
@@ -42,7 +42,7 @@ namespace Xidi
 
     /// Maximum possible reading from an XInput controller's trigger.
     /// Value taken from XInput documentation.
-    inline constexpr int32_t kTriggerValueMax = 255;
+    inline constexpr int32_t kTriggerValueMax = 32767;
 
     /// Maximum possible reading from an XInput controller's trigger.
     /// Value taken from XInput documentation.
@@ -469,26 +469,26 @@ namespace Xidi
 
     /// Enumerates all digital buttons that might be present on a physical controller. As an
     /// implementation simplification, the order of enumerators corresponds to the ordering used in
-    /// XInput. One enumerator exists per possible button. Guide and Share buttons are not actually
+    /// SDL3. One enumerator exists per possible button. Guide and Share buttons are not actually
     /// used, but they still have space allocated for them on a speculative basis.
     enum class EPhysicalButton : uint8_t
     {
-      DpadUp,
-      DpadDown,
-      DpadLeft,
-      DpadRight,
-      Start,
-      Back,
-      LS,
-      RS,
-      LB,
-      RB,
-      UnusedGuide,
-      UnusedShare,
       A,
       B,
       X,
       Y,
+      Back,
+      UnusedGuide,
+      Start,
+      LS,
+      RS,
+      LB,
+      RB,
+      DpadUp,
+      DpadDown,
+      DpadLeft,
+      DpadRight,
+      UnusedShare,
 
       /// Sentinel value, total number of enumerators
       Count
@@ -507,7 +507,7 @@ namespace Xidi
       std::array<int16_t, static_cast<int>(EPhysicalStick::Count)> stick;
 
       /// Analog trigger values read from the physical controller, one element per possible trigger.
-      std::array<uint8_t, static_cast<int>(EPhysicalTrigger::Count)> trigger;
+      std::array<int16_t, static_cast<int>(EPhysicalTrigger::Count)> trigger;
 
       /// Digital button values read from the physical controller, one element per possible digital
       /// button.
@@ -520,7 +520,7 @@ namespace Xidi
         return stick[static_cast<int>(desiredStick)];
       }
 
-      constexpr uint8_t operator[](EPhysicalTrigger desiredTrigger) const
+      constexpr int16_t operator[](EPhysicalTrigger desiredTrigger) const
       {
         return trigger[static_cast<int>(desiredTrigger)];
       }
@@ -546,6 +546,6 @@ namespace Xidi
       }
     };
 
-    static_assert(sizeof(SPhysicalState) <= 16, "Data structure size constraint violation.");
+    static_assert(sizeof(SPhysicalState) <= 20, "Data structure size constraint violation.");
   } // namespace Controller
 } // namespace Xidi

--- a/Include/Xidi/Internal/ElementMapper.h
+++ b/Include/Xidi/Internal/ElementMapper.h
@@ -70,7 +70,7 @@ namespace Xidi
       /// @param [in] sourceIdentifier Opaque identifier for the specific controller element that is
       /// triggering the contribution.
       virtual void ContributeFromTriggerValue(
-          SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const = 0;
+          SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const = 0;
 
       /// Specifies that the element mapper should make a neutral state contribution to the virtual
       /// controller. Primarily intended for element mappers that have side effects so that they can
@@ -136,7 +136,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
       std::optional<SElementIdentifier> GetTargetElementAt(int index) const override;
@@ -176,7 +176,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
       std::optional<SElementIdentifier> GetTargetElementAt(int index) const override;
@@ -227,7 +227,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
@@ -284,7 +284,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
     };
 
@@ -322,7 +322,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
@@ -365,7 +365,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
@@ -416,7 +416,7 @@ namespace Xidi
       void ContributeFromButtonValue(
           SState& controllerState, bool buttonPressed, uint32_t sourceIdentifier) const override;
       void ContributeFromTriggerValue(
-          SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const override;
+          SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier) const override;
       int GetTargetElementCount(void) const override;
       std::optional<SElementIdentifier> GetTargetElementAt(int index) const override;
@@ -464,7 +464,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
@@ -505,7 +505,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;
       std::optional<SElementIdentifier> GetTargetElementAt(int index) const override;
@@ -570,7 +570,7 @@ namespace Xidi
           uint32_t sourceIdentifier = 0) const override;
       void ContributeFromTriggerValue(
           SState& controllerState,
-          uint8_t triggerValue,
+          int16_t triggerValue,
           uint32_t sourceIdentifier = 0) const override;
       void ContributeNeutral(SState& controllerState, uint32_t sourceIdentifier = 0) const override;
       int GetTargetElementCount(void) const override;

--- a/Include/Xidi/Internal/PhysicalController.h
+++ b/Include/Xidi/Internal/PhysicalController.h
@@ -13,6 +13,8 @@
 
 #include <stop_token>
 
+#include <SDL3/SDL_gamepad.h>
+
 #include "ApiWindows.h"
 #include "ControllerTypes.h"
 #include "ForceFeedbackDevice.h"

--- a/Include/Xidi/Test/MockElementMapper.h
+++ b/Include/Xidi/Test/MockElementMapper.h
@@ -141,7 +141,7 @@ namespace XidiTest
     }
 
     void ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const override
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const override
     {
       if (EExpectedSource::Trigger != maybeExpectedSource.value_or(EExpectedSource::Trigger))
         TEST_FAILED_BECAUSE(

--- a/Properties/DInput.props
+++ b/Properties/DInput.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProductName>Xidi</ProductName>
-    <ThirdPartyDeps>Boost,XstdBitSet</ThirdPartyDeps>
+    <ThirdPartyDeps>Boost,XstdBitSet,SDL3</ThirdPartyDeps>
   </PropertyGroup>
 </Project>

--- a/Properties/DInput8.props
+++ b/Properties/DInput8.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProductName>Xidi</ProductName>
-    <ThirdPartyDeps>Boost,XstdBitSet</ThirdPartyDeps>
+    <ThirdPartyDeps>Boost,XstdBitSet,SDL3</ThirdPartyDeps>
   </PropertyGroup>
 </Project>

--- a/Properties/WinMM.props
+++ b/Properties/WinMM.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProductName>Xidi</ProductName>
-    <ThirdPartyDeps>Boost,XstdBitSet</ThirdPartyDeps>
+    <ThirdPartyDeps>Boost,XstdBitSet,SDL3</ThirdPartyDeps>
   </PropertyGroup>
 </Project>

--- a/Properties/XidiTest.props
+++ b/Properties/XidiTest.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProductName>Xidi</ProductName>
-    <ThirdPartyDeps>Boost,XstdBitSet</ThirdPartyDeps>
+    <ThirdPartyDeps>Boost,XstdBitSet,SDL3</ThirdPartyDeps>
   </PropertyGroup>
 </Project>

--- a/Source/ControllerMath.cpp
+++ b/Source/ControllerMath.cpp
@@ -46,19 +46,19 @@ namespace Xidi
         return kAnalogValueNeutral + (int16_t)(transformedAnalogBase * transformationScaleFactor);
       }
 
-      uint8_t ApplyRawTriggerTransform(
-          uint8_t triggerValue, unsigned int deadzonePercent, unsigned int saturationPercent)
+      int16_t ApplyRawTriggerTransform(
+          int16_t triggerValue, unsigned int deadzonePercent, unsigned int saturationPercent)
       {
         if ((0 == deadzonePercent) && (100 == saturationPercent)) return triggerValue;
 
-        const uint8_t deadzoneCutoff =
-            (uint8_t)((((unsigned int)kTriggerValueMax - (unsigned int)kTriggerValueMin) *
+        const int16_t deadzoneCutoff =
+            (int16_t)((((unsigned int)kTriggerValueMax - (unsigned int)kTriggerValueMin) *
                        deadzonePercent) /
                       100);
         if (triggerValue <= deadzoneCutoff) return kTriggerValueMin;
 
-        const uint8_t saturationCutoff =
-            (uint8_t)((((unsigned int)kTriggerValueMax - (unsigned int)kTriggerValueMin) *
+        const int16_t saturationCutoff =
+            (int16_t)((((unsigned int)kTriggerValueMax - (unsigned int)kTriggerValueMin) *
                        saturationPercent) /
                       100);
         if (triggerValue >= saturationCutoff) return kTriggerValueMax;
@@ -67,7 +67,7 @@ namespace Xidi
         const float transformationScaleFactor = ((float)(kTriggerValueMax - kTriggerValueMin)) /
             ((float)(saturationCutoff - deadzoneCutoff));
 
-        return kTriggerValueMin + (uint8_t)(transformedTriggerBase * transformationScaleFactor);
+        return kTriggerValueMin + (int16_t)(transformedTriggerBase * transformationScaleFactor);
       }
 
       SAnalogStickCoordinates TransformCoordinatesCircleToSquare(

--- a/Source/ElementMapper.cpp
+++ b/Source/ElementMapper.cpp
@@ -78,7 +78,7 @@ namespace Xidi
     }
 
     void AxisMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       constexpr double kBidirectionalStepSize = (double)(kAnalogValueMax - kAnalogValueMin) /
           (double)(kTriggerValueMax - kTriggerValueMin);
@@ -140,7 +140,7 @@ namespace Xidi
     }
 
     void ButtonMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       controllerState[button] = (controllerState[button] || Math::IsTriggerPressed(triggerValue));
     }
@@ -184,7 +184,7 @@ namespace Xidi
     }
 
     void CompoundMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       for (const auto& elementMapper : elementMappers)
       {
@@ -267,7 +267,7 @@ namespace Xidi
     }
 
     void DigitalAxisMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       ContributeFromButtonValue(
           controllerState, Math::IsTriggerPressed(triggerValue), sourceIdentifier);
@@ -302,14 +302,14 @@ namespace Xidi
     }
 
     void InvertMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       if (nullptr != elementMapper)
       {
         const int32_t invertedTriggerValue =
             (kTriggerValueMax + kTriggerValueMin) - (int32_t)triggerValue;
         elementMapper->ContributeFromTriggerValue(
-            controllerState, (uint8_t)invertedTriggerValue, sourceIdentifier);
+            controllerState, (int16_t)invertedTriggerValue, sourceIdentifier);
       }
     }
 
@@ -357,7 +357,7 @@ namespace Xidi
     }
 
     void KeyboardMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       if (true == Math::IsTriggerPressed(triggerValue))
         Keyboard::SubmitKeyPressedState(key);
@@ -471,7 +471,7 @@ namespace Xidi
     }
 
     void MouseAxisMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       static const bool kEnableMouseAxisProperites =
           Globals::GetConfigurationData()
@@ -489,7 +489,7 @@ namespace Xidi
 
       constexpr unsigned int kTriggerMouseDeadzonePercent = 8;
       constexpr unsigned int kTriggerMouseSaturationPercent = 92;
-      const uint8_t triggerValueForContribution =
+      const int16_t triggerValueForContribution =
           (kEnableMouseAxisProperites
                ? Math::ApplyRawTriggerTransform(
                      triggerValue, kTriggerMouseDeadzonePercent, kTriggerMouseSaturationPercent)
@@ -561,7 +561,7 @@ namespace Xidi
     }
 
     void MouseButtonMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       if (true == Math::IsTriggerPressed(triggerValue))
         Mouse::SubmitMouseButtonPressedState(mouseButton);
@@ -604,7 +604,7 @@ namespace Xidi
     }
 
     void PovMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       if (true == Math::IsTriggerPressed(triggerValue))
         controllerState.povDirection.components[(int)povDirection] = true;
@@ -670,7 +670,7 @@ namespace Xidi
     }
 
     void SplitMapper::ContributeFromTriggerValue(
-        SState& controllerState, uint8_t triggerValue, uint32_t sourceIdentifier) const
+        SState& controllerState, int16_t triggerValue, uint32_t sourceIdentifier) const
     {
       if ((int32_t)triggerValue >= kTriggerValueMid)
       {

--- a/Source/ImportApiDirectInput.cpp
+++ b/Source/ImportApiDirectInput.cpp
@@ -16,6 +16,8 @@
 #include <mutex>
 #include <string_view>
 
+#include <SDL3/SDL.h>
+
 #include <Infra/Core/Configuration.h>
 #include <Infra/Core/Message.h>
 #include <Infra/Core/ProcessInfo.h>
@@ -127,7 +129,7 @@ namespace Xidi
           libraryPath);
     }
 
-    /// Dynamically loads the DirectInput 8 and sets up all imported function calls.
+    /// Dynamically loads DirectInput 8 and sets up all imported function calls.
     static void InitializeVersion8(void)
     {
       static std::once_flag initializeFlag;
@@ -135,6 +137,10 @@ namespace Xidi
           initializeFlag,
           []() -> void
           {
+            // Initialize SDL3.
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+            SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC);
+
             ZeroMemory(&importTableVersion8, sizeof(importTableVersion8));
 
             std::wstring_view libraryPath = GetImportLibraryPathDirectInput8();
@@ -162,7 +168,7 @@ namespace Xidi
           });
     }
 
-    /// Dynamically loads the DirectInput 8 and sets up all imported function calls.
+    /// Dynamically loads DirectInput and sets up all imported function calls.
     static void InitializeVersionLegacy(void)
     {
       static std::once_flag initializeFlag;
@@ -170,6 +176,10 @@ namespace Xidi
           initializeFlag,
           []() -> void
           {
+            // Initialize SDL3.
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+            SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC);
+
             ZeroMemory(&importTableVersionLegacy, sizeof(importTableVersionLegacy));
 
             std::wstring_view libraryPath = GetImportLibraryPathDirectInput();

--- a/Source/ImportApiWinMM.cpp
+++ b/Source/ImportApiWinMM.cpp
@@ -17,6 +17,8 @@
 #include <set>
 #include <string_view>
 
+#include <SDL3/SDL.h>
+
 #include <Infra/Core/Configuration.h>
 #include <Infra/Core/Message.h>
 #include <Infra/Core/ProcessInfo.h>
@@ -92,6 +94,10 @@ namespace Xidi
           initializeFlag,
           []() -> void
           {
+            // Initialize SDL3.
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+            SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC);
+
             // Initialize the import table.
             ZeroMemory(&importTable, sizeof(importTable));
 

--- a/Source/Mapper.cpp
+++ b/Source/Mapper.cpp
@@ -668,7 +668,7 @@ namespace Xidi
         elements.named.stickLeftY->ContributeFromAnalogValue(
             controllerState,
             Math::ApplyRawAnalogTransform(
-                FilterAndInvertAnalogStickValue(stickLeftCoordinates.y),
+                FilterAnalogStickValue(stickLeftCoordinates.y),
                 kDeadzonePercentStickLeft,
                 kSaturationPercentStickLeft),
             SourceIdentifierForElementMapper(
@@ -687,7 +687,7 @@ namespace Xidi
         elements.named.stickRightY->ContributeFromAnalogValue(
             controllerState,
             Math::ApplyRawAnalogTransform(
-                FilterAndInvertAnalogStickValue(stickRightCoordinates.y),
+                FilterAnalogStickValue(stickRightCoordinates.y),
                 kDeadzonePercentStickRight,
                 kSaturationPercentStickRight),
             SourceIdentifierForElementMapper(

--- a/Source/Test/Case/ControllerMathTest.cpp
+++ b/Source/Test/Case/ControllerMathTest.cpp
@@ -152,7 +152,16 @@ namespace XidiTest
     constexpr unsigned int kDeadzonePercent = 0;
     constexpr unsigned int kSaturationPercent = 100;
 
-    constexpr uint8_t kTestValues[] = {0, 31, 63, 127, 159, 191, 223, 255};
+    constexpr int16_t kTestValues[] = {
+        0,
+        (32767 * 1 / 8),
+        (32767 * 1 / 4),
+        (32767 * 1 / 2),
+        (32767 * 5 / 8),
+        (32767 * 3 / 4),
+        (32767 * 7 / 8),
+        32767
+    };
 
     for (const auto& testValue : kTestValues)
     {
@@ -169,16 +178,16 @@ namespace XidiTest
 
     constexpr struct
     {
-      uint8_t rawInput;
-      uint8_t expectedOutput;
+      int16_t rawInput;
+      int16_t expectedOutput;
     } kTestValues[] = {
         {.rawInput = 0, .expectedOutput = 0},
-        {.rawInput = 255, .expectedOutput = 255},
-        {.rawInput = (255 * 1 / 8), .expectedOutput = 0},
-        {.rawInput = (255 * 1 / 4), .expectedOutput = 0},
-        {.rawInput = (255 * 1 / 2), .expectedOutput = 0},
-        {.rawInput = (255 * 3 / 4), .expectedOutput = (255 * 1 / 2)},
-        {.rawInput = (255 * 7 / 8), .expectedOutput = (255 * 3 / 4)},
+        {.rawInput = 32767, .expectedOutput = 32767},
+        {.rawInput = (32767 * 1 / 8), .expectedOutput = 0},
+        {.rawInput = (32767 * 1 / 4), .expectedOutput = 0},
+        {.rawInput = (32767 * 1 / 2), .expectedOutput = 0},
+        {.rawInput = (32767 * 3 / 4), .expectedOutput = (32767 * 1 / 2)},
+        {.rawInput = (32767 * 7 / 8), .expectedOutput = (32767 * 3 / 4)},
     };
 
     for (const auto& testValue : kTestValues)
@@ -197,16 +206,16 @@ namespace XidiTest
 
     constexpr struct
     {
-      uint8_t rawInput;
-      uint8_t expectedOutput;
+      int16_t rawInput;
+      int16_t expectedOutput;
     } kTestValues[] = {
         {.rawInput = 0, .expectedOutput = 0},
-        {.rawInput = 255, .expectedOutput = 255},
-        {.rawInput = (255 * 1 / 8), .expectedOutput = (255 * 1 / 4)},
-        {.rawInput = (255 * 1 / 4), .expectedOutput = (255 * 1 / 2)},
-        {.rawInput = (255 * 1 / 2), .expectedOutput = 255},
-        {.rawInput = (255 * 3 / 4), .expectedOutput = 255},
-        {.rawInput = (255 * 7 / 8), .expectedOutput = 255},
+        {.rawInput = 32767, .expectedOutput = 32767},
+        {.rawInput = (32767 * 1 / 8), .expectedOutput = (32767 * 1 / 4)},
+        {.rawInput = (32767 * 1 / 4), .expectedOutput = (32767 * 1 / 2)},
+        {.rawInput = (32767 * 1 / 2), .expectedOutput = 32767},
+        {.rawInput = (32767 * 3 / 4), .expectedOutput = 32767},
+        {.rawInput = (32767 * 7 / 8), .expectedOutput = 32767},
     };
 
     for (const auto& testValue : kTestValues)
@@ -226,16 +235,16 @@ namespace XidiTest
 
     constexpr struct
     {
-      uint8_t rawInput;
-      uint8_t expectedOutput;
+      int16_t rawInput;
+      int16_t expectedOutput;
     } kTestValues[] = {
         {.rawInput = 0, .expectedOutput = 0},
-        {.rawInput = 255, .expectedOutput = 255},
-        {.rawInput = (255 * 1 / 8), .expectedOutput = 0},
-        {.rawInput = (255 * 1 / 4), .expectedOutput = 0},
-        {.rawInput = (255 * 1 / 2), .expectedOutput = (255 * 1 / 2)},
-        {.rawInput = (255 * 3 / 4), .expectedOutput = 255},
-        {.rawInput = (255 * 7 / 8), .expectedOutput = 255},
+        {.rawInput = 32767, .expectedOutput = 32767},
+        {.rawInput = (32767 * 1 / 8), .expectedOutput = 0},
+        {.rawInput = (32767 * 1 / 4), .expectedOutput = 0},
+        {.rawInput = (32767 * 1 / 2), .expectedOutput = (32767 * 1 / 2)},
+        {.rawInput = (32767 * 3 / 4), .expectedOutput = 32767},
+        {.rawInput = (32767 * 7 / 8), .expectedOutput = 32767},
     };
 
     for (const auto& testValue : kTestValues)

--- a/Source/Test/Case/KeyboardMapperTest.cpp
+++ b/Source/Test/Case/KeyboardMapperTest.cpp
@@ -265,8 +265,8 @@ namespace XidiTest
   // mapper pressing, then unpressing, a keyboard key.
   TEST_CASE(KeyboardMapper_ContributeFromTriggerValue_PressUnpressSequence)
   {
-    constexpr uint8_t kTriggerValuePress = kTriggerValueMax;
-    constexpr uint8_t kTriggerValueRelease = kTriggerValueMin;
+    constexpr int16_t kTriggerValuePress = kTriggerValueMax;
+    constexpr int16_t kTriggerValueRelease = kTriggerValueMin;
 
     MockKeyboard expectedKeyboardStateUnpressed;
 

--- a/Source/Test/Case/MouseButtonMapperTest.cpp
+++ b/Source/Test/Case/MouseButtonMapperTest.cpp
@@ -279,8 +279,8 @@ namespace XidiTest
   // button mapper pressing, then unpressing, a mouse button.
   TEST_CASE(MouseButtonMapper_ContributeFromTriggerValue_PressUnpressSequence)
   {
-    constexpr uint8_t kTriggerValuePress = kTriggerValueMax;
-    constexpr uint8_t kTriggerValueRelease = kTriggerValueMin;
+    constexpr int16_t kTriggerValuePress = kTriggerValueMax;
+    constexpr int16_t kTriggerValueRelease = kTriggerValueMin;
 
     MockMouse expectedMouseStateUnpressed;
 

--- a/Source/Test/Case/SplitMapperTest.cpp
+++ b/Source/Test/Case/SplitMapperTest.cpp
@@ -280,8 +280,8 @@ namespace XidiTest
   {
     constexpr struct
     {
-      uint8_t positive;
-      uint8_t negative;
+      int16_t positive;
+      int16_t negative;
     } kTestValues[] = {
         {.positive = kTriggerValueMax, .negative = kTriggerValueMin},
         {.positive = kTriggerValueMax / 2, .negative = kTriggerValueMin / 2},
@@ -319,8 +319,8 @@ namespace XidiTest
   {
     constexpr struct
     {
-      uint8_t positive;
-      uint8_t negative;
+      int16_t positive;
+      int16_t negative;
     } kTestValues[] = {
         {.positive = kTriggerValueMax, .negative = kTriggerValueMin},
         {.positive = kTriggerValueMax / 2, .negative = kTriggerValueMin / 2},

--- a/Source/WrapperIDirectInput.cpp
+++ b/Source/WrapperIDirectInput.cpp
@@ -125,7 +125,7 @@ namespace Xidi
           const HRESULT deviceInfoResult = createdDevice->GetDeviceInfo(&deviceInfo);
 
           const bool deviceSupportsXInput =
-              DoesDirectInputControllerSupportXInput<diVersion>(underlyingDIObject, rguid);
+              DoesDirectInputControllerSupportSdlGamepad<diVersion>(underlyingDIObject, rguid);
           if (true == deviceSupportsXInput)
           {
             if (Infra::Message::WillOutputMessageOfSeverity(Infra::Message::ESeverity::Info))
@@ -363,7 +363,7 @@ namespace Xidi
 
     // If the present controller supports XInput, indicate such by adding it to the set of instance
     // identifiers of interest.
-    if (DoesDirectInputControllerSupportXInput<diVersion>(
+    if (DoesDirectInputControllerSupportSdlGamepad<diVersion>(
             callbackInfo->instance->underlyingDIObject, lpddi->guidInstance))
     {
       callbackInfo->seenInstanceIdentifiers.insert(lpddi->guidInstance);

--- a/Source/WrapperJoyWinMM.cpp
+++ b/Source/WrapperJoyWinMM.cpp
@@ -234,7 +234,7 @@ namespace Xidi
       SWinMMEnumCallbackInfo* callbackInfo = (SWinMMEnumCallbackInfo*)pvRef;
 
       std::wstring devicePath;
-      bool deviceSupportsXInput = DoesDirectInputControllerSupportXInput<EDirectInputVersion::k8W>(
+      bool deviceSupportsXInput = DoesDirectInputControllerSupportSdlGamepad<EDirectInputVersion::k8W>(
           callbackInfo->directInputInterface, lpddi->guidInstance, &devicePath);
 
       if (deviceSupportsXInput)

--- a/ThirdParty/SDL3/SDL.vcxproj
+++ b/ThirdParty/SDL3/SDL.vcxproj
@@ -1,0 +1,748 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>SDL3</ProjectName>
+    <ProjectGuid>{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}</ProjectGuid>
+    <RootNamespace>SDL</RootNamespace>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>$(ProjectDir)/Files/src;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>$(ProjectDir)/Files/src;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(ProjectDir)/Files/src;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(ProjectDir)/Files/src;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>.\Debug/SDL.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(ProjectDir)/Files/include;$(ProjectDir)/Files/include/build_config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <DisableSpecificWarnings>4100;4127;4152;4201</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>setupapi.lib;winmm.lib;imm32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <Lib />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>X64</TargetEnvironment>
+      <TypeLibraryName>.\Debug/SDL.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(ProjectDir)/Files/include;$(ProjectDir)/Files/include/build_config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>DLL_EXPORT;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <DisableSpecificWarnings>4100;4127;4152;4201</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>setupapi.lib;winmm.lib;imm32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <Lib />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>.\Release/SDL.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)/Files/include;$(ProjectDir)/Files/include/build_config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <DisableSpecificWarnings>4100;4127;4152;4201</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>setupapi.lib;winmm.lib;imm32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <Lib />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>X64</TargetEnvironment>
+      <TypeLibraryName>.\Release/SDL.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)/Files/include;$(ProjectDir)/Files/include/build_config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <DisableSpecificWarnings>4100;4127;4152;4201</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>setupapi.lib;winmm.lib;imm32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <Lib />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(TreatWarningsAsError)'!=''">
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
+      <TreatWarningAsError>$(TreatWarningsAsError)</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Files\include\SDL3\SDL_begin_code.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_camera.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_close_code.h" />
+    <ClInclude Include="Files\include\SDL3\SDL.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_assert.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_atomic.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_audio.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_bits.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_blendmode.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_clipboard.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_copying.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_cpuinfo.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_egl.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_endian.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_error.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_events.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_filesystem.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_gamepad.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_gpu.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_guid.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_haptic.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_hints.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_hidapi.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_asyncio.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_joystick.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_keyboard.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_keycode.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_loadso.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_locale.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_log.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_main.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_messagebox.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_metal.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_misc.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_mouse.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_mutex.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengl.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengl_glext.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2ext.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2platform.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_khrplatform.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_pen.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_pixels.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_platform.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_platform_defines.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_power.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_process.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_properties.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_rect.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_render.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_revision.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_iostream.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_scancode.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_sensor.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_stdinc.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_storage.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_surface.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_system.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_assert.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_common.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_compare.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_crc32.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_font.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_fuzzer.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_harness.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_log.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_md5.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_test_memory.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_thread.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_time.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_timer.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_touch.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_version.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_video.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_vulkan.h" />
+    <ClInclude Include="Files\src\audio\directsound\SDL_directsound.h" />
+    <ClInclude Include="Files\src\audio\disk\SDL_diskaudio.h" />
+    <ClInclude Include="Files\src\audio\dummy\SDL_dummyaudio.h" />
+    <ClInclude Include="Files\src\audio\SDL_audio_c.h" />
+    <ClInclude Include="Files\src\audio\SDL_audiodev_c.h" />
+    <ClInclude Include="Files\src\audio\SDL_sysaudio.h" />
+    <ClInclude Include="Files\src\audio\SDL_audioqueue.h" />
+    <ClInclude Include="Files\src\audio\SDL_audioresample.h" />
+    <ClInclude Include="Files\src\audio\SDL_wave.h" />
+    <ClInclude Include="Files\src\audio\wasapi\SDL_wasapi.h" />
+    <ClInclude Include="Files\src\camera\SDL_camera_c.h" />
+    <ClInclude Include="Files\src\camera\SDL_syscamera.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_directx.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_gameinput.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_hid.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_immdevice.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_windows.h" />
+    <ClInclude Include="Files\src\core\windows\SDL_xinput.h" />
+    <ClInclude Include="Files\src\cpuinfo\SDL_cpuinfo_c.h" />
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi.h" />
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_overrides.h" />
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_procs.h" />
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_unsupported.h" />
+    <ClInclude Include="Files\src\events\blank_cursor.h" />
+    <ClInclude Include="Files\src\events\default_cursor.h" />
+    <ClInclude Include="Files\src\events\scancodes_windows.h" />
+    <ClInclude Include="Files\src\events\SDL_categories_c.h" />
+    <ClInclude Include="Files\src\events\SDL_clipboardevents_c.h" />
+    <ClInclude Include="Files\src\events\SDL_displayevents_c.h" />
+    <ClInclude Include="Files\src\events\SDL_dropevents_c.h" />
+    <ClInclude Include="Files\src\events\SDL_events_c.h" />
+    <ClInclude Include="Files\src\events\SDL_eventwatch_c.h" />
+    <ClInclude Include="Files\src\events\SDL_keyboard_c.h" />
+    <ClInclude Include="Files\src\events\SDL_keymap_c.h" />
+    <ClInclude Include="Files\src\events\SDL_mouse_c.h" />
+    <ClInclude Include="Files\src\events\SDL_touch_c.h" />
+    <ClInclude Include="Files\src\events\SDL_windowevents_c.h" />
+    <ClInclude Include="Files\src\filesystem\SDL_sysfilesystem.h" />
+    <ClInclude Include="Files\src\gpu\SDL_sysgpu.h" />
+    <ClInclude Include="Files\src\gpu\vulkan\SDL_gpu_vulkan_vkfuncs.h" />
+    <ClInclude Include="Files\src\io\SDL_asyncio_c.h" />
+    <ClInclude Include="Files\src\io\SDL_sysasyncio.h" />
+    <ClInclude Include="Files\src\haptic\SDL_haptic_c.h" />
+    <ClInclude Include="Files\src\haptic\SDL_syshaptic.h" />
+    <ClInclude Include="Files\src\haptic\windows\SDL_dinputhaptic_c.h" />
+    <ClInclude Include="Files\src\haptic\windows\SDL_windowshaptic_c.h" />
+    <ClInclude Include="Files\src\hidapi\hidapi\hidapi.h" />
+    <ClInclude Include="Files\src\hidapi\SDL_hidapi_c.h" />
+    <ClInclude Include="Files\src\joystick\controller_type.h" />
+    <ClInclude Include="Files\src\joystick\hidapi\SDL_hidapijoystick_c.h" />
+    <ClInclude Include="Files\src\joystick\hidapi\SDL_hidapi_rumble.h" />
+    <ClInclude Include="Files\src\joystick\SDL_gamepad_c.h" />
+    <ClInclude Include="Files\src\joystick\SDL_gamepad_db.h" />
+    <ClInclude Include="Files\src\joystick\SDL_joystick_c.h" />
+    <ClInclude Include="Files\src\joystick\SDL_steam_virtual_gamepad.h" />
+    <ClInclude Include="Files\src\joystick\SDL_sysjoystick.h" />
+    <ClInclude Include="Files\src\joystick\usb_ids.h" />
+    <ClInclude Include="Files\src\joystick\virtual\SDL_virtualjoystick_c.h" />
+    <ClInclude Include="Files\src\joystick\windows\SDL_dinputjoystick_c.h" />
+    <ClInclude Include="Files\src\joystick\windows\SDL_rawinputjoystick_c.h" />
+    <ClInclude Include="Files\src\joystick\windows\SDL_windowsjoystick_c.h" />
+    <ClInclude Include="Files\src\joystick\windows\SDL_xinputjoystick_c.h" />
+    <ClInclude Include="Files\src\libm\math_libm.h" />
+    <ClInclude Include="Files\src\libm\math_private.h" />
+    <ClInclude Include="Files\src\locale\SDL_syslocale.h" />
+    <ClInclude Include="Files\src\main\SDL_main_callbacks.h" />
+    <ClInclude Include="Files\src\misc\SDL_sysurl.h" />
+    <ClInclude Include="Files\src\power\SDL_syspower.h" />
+    <ClInclude Include="Files\src\render\direct3d11\SDL_shaders_d3d11.h" />
+    <ClInclude Include="Files\src\render\direct3d12\SDL_shaders_d3d12.h" />
+    <ClInclude Include="Files\src\render\direct3d\SDL_shaders_d3d.h" />
+    <ClInclude Include="Files\src\render\opengles2\SDL_gles2funcs.h" />
+    <ClInclude Include="Files\src\render\opengles2\SDL_shaders_gles2.h" />
+    <ClInclude Include="Files\src\render\opengl\SDL_glfuncs.h" />
+    <ClInclude Include="Files\src\render\opengl\SDL_shaders_gl.h" />
+    <ClInclude Include="Files\src\render\SDL_d3dmath.h" />
+    <ClInclude Include="Files\src\render\SDL_sysrender.h" />
+    <ClInclude Include="Files\src\render\SDL_yuv_sw_c.h" />
+    <ClInclude Include="Files\src\render\software\SDL_blendfillrect.h" />
+    <ClInclude Include="Files\src\render\software\SDL_blendline.h" />
+    <ClInclude Include="Files\src\render\software\SDL_blendpoint.h" />
+    <ClInclude Include="Files\src\render\software\SDL_draw.h" />
+    <ClInclude Include="Files\src\render\software\SDL_drawline.h" />
+    <ClInclude Include="Files\src\render\software\SDL_drawpoint.h" />
+    <ClInclude Include="Files\src\render\software\SDL_render_sw_c.h" />
+    <ClInclude Include="Files\src\render\software\SDL_rotate.h" />
+    <ClInclude Include="Files\src\render\software\SDL_triangle.h" />
+    <ClInclude Include="Files\src\render\vulkan\SDL_shaders_vulkan.h" />
+    <ClInclude Include="Files\src\SDL_assert_c.h" />
+    <ClInclude Include="Files\src\SDL_error_c.h" />
+    <ClCompile Include="Files\src\core\windows\pch.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="Files\src\camera\dummy\SDL_camera_dummy.c" />
+    <ClCompile Include="Files\src\camera\mediafoundation\SDL_camera_mediafoundation.c" />
+    <ClCompile Include="Files\src\camera\SDL_camera.c" />
+    <ClCompile Include="Files\src\dialog\SDL_dialog.c" />
+    <ClCompile Include="Files\src\dialog\SDL_dialog_utils.c" />
+    <ClCompile Include="Files\src\filesystem\SDL_filesystem.c" />
+    <ClCompile Include="Files\src\filesystem\windows\SDL_sysfsops.c" />
+    <ClCompile Include="Files\src\io\windows\SDL_asyncio_windows_ioring.c" />
+    <ClCompile Include="Files\src\gpu\SDL_gpu.c" />
+    <ClCompile Include="Files\src\gpu\d3d12\SDL_gpu_d3d12.c" />
+    <ClCompile Include="Files\src\gpu\vulkan\SDL_gpu_vulkan.c" />
+    <ClCompile Include="Files\src\io\generic\SDL_asyncio_generic.c" />
+    <ClCompile Include="Files\src\io\SDL_asyncio.c" />
+    <ClCompile Include="Files\src\main\generic\SDL_sysmain_callbacks.c" />
+    <ClCompile Include="Files\src\main\SDL_main_callbacks.c" />
+    <ClCompile Include="Files\src\main\SDL_runapp.c" />
+    <ClCompile Include="Files\src\main\windows\SDL_sysmain_runapp.c" />
+    <ClCompile Include="Files\src\render\vulkan\SDL_render_vulkan.c" />
+    <ClCompile Include="Files\src\render\vulkan\SDL_shaders_vulkan.c" />
+    <ClCompile Include="Files\src\SDL_guid.c" />
+    <ClInclude Include="Files\src\SDL_hashtable.h" />
+    <ClInclude Include="Files\src\SDL_hints_c.h" />
+    <ClInclude Include="Files\src\SDL_internal.h" />
+    <ClInclude Include="Files\src\SDL_list.h" />
+    <ClInclude Include="Files\src\SDL_log_c.h" />
+    <ClInclude Include="Files\src\SDL_properties_c.h" />
+    <ClInclude Include="Files\src\sensor\dummy\SDL_dummysensor.h" />
+    <ClInclude Include="Files\src\sensor\SDL_sensor_c.h" />
+    <ClInclude Include="Files\src\sensor\SDL_syssensor.h" />
+    <ClInclude Include="Files\src\sensor\windows\SDL_windowssensor.h" />
+    <ClInclude Include="Files\src\thread\SDL_systhread.h" />
+    <ClInclude Include="Files\src\thread\SDL_thread_c.h" />
+    <ClInclude Include="Files\src\thread\generic\SDL_syscond_c.h" />
+    <ClInclude Include="Files\src\thread\windows\SDL_sysmutex_c.h" />
+    <ClInclude Include="Files\src\thread\generic\SDL_sysrwlock_c.h" />
+    <ClInclude Include="Files\src\thread\windows\SDL_systhread_c.h" />
+    <ClInclude Include="Files\src\timer\SDL_timer_c.h" />
+    <ClInclude Include="Files\src\video\dummy\SDL_nullevents_c.h" />
+    <ClInclude Include="Files\src\video\dummy\SDL_nullframebuffer_c.h" />
+    <ClInclude Include="Files\src\video\dummy\SDL_nullvideo.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_icd.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_layer.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_platform.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_sdk_platform.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_android.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_beta.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_core.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_directfb.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_fuchsia.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_ggp.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_ios.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_macos.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_metal.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_vi.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_wayland.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_win32.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xcb.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xlib.h" />
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xlib_xrandr.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenevents_c.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenframebuffer_c.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenopengles.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenvideo.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenvulkan.h" />
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenwindow.h" />
+    <ClInclude Include="Files\src\video\SDL_blit.h" />
+    <ClInclude Include="Files\src\video\SDL_blit_auto.h" />
+    <ClInclude Include="Files\src\video\SDL_blit_copy.h" />
+    <ClInclude Include="Files\src\video\SDL_blit_slow.h" />
+    <ClInclude Include="Files\src\video\SDL_clipboard_c.h" />
+    <ClInclude Include="Files\src\video\SDL_egl_c.h" />
+    <ClInclude Include="Files\src\video\SDL_pixels_c.h" />
+    <ClInclude Include="Files\src\video\SDL_rect_c.h" />
+    <ClInclude Include="Files\src\video\SDL_RLEaccel_c.h" />
+    <ClInclude Include="Files\src\video\SDL_stb_c.h" />
+    <ClInclude Include="Files\src\video\SDL_surface_c.h" />
+    <ClInclude Include="Files\src\video\SDL_sysvideo.h" />
+    <ClInclude Include="Files\src\video\SDL_vulkan_internal.h" />
+    <ClInclude Include="Files\src\video\SDL_yuv_c.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_msctf.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_surface_utils.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsclipboard.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsevents.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsframebuffer.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowskeyboard.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsgameinput.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmessagebox.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmodes.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmouse.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsopengl.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsopengles.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsrawinput.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsshape.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsvideo.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowsvulkan.h" />
+    <ClInclude Include="Files\src\video\windows\SDL_windowswindow.h" />
+    <ClInclude Include="Files\src\video\windows\wmmsg.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_common.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_internal.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_lsx.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_lsx_func.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_sse.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_sse_func.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_std.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_std_func.h" />
+    <ClCompile Include="Files\src\atomic\SDL_atomic.c" />
+    <ClCompile Include="Files\src\atomic\SDL_spinlock.c" />
+    <ClCompile Include="Files\src\audio\directsound\SDL_directsound.c" />
+    <ClCompile Include="Files\src\audio\disk\SDL_diskaudio.c" />
+    <ClCompile Include="Files\src\audio\dummy\SDL_dummyaudio.c" />
+    <ClCompile Include="Files\src\audio\SDL_audio.c" />
+    <ClCompile Include="Files\src\audio\SDL_audiocvt.c" />
+    <ClCompile Include="Files\src\audio\SDL_audiodev.c" />
+    <ClCompile Include="Files\src\audio\SDL_audiotypecvt.c" />
+    <ClCompile Include="Files\src\audio\SDL_audioqueue.c" />
+    <ClCompile Include="Files\src\audio\SDL_audioresample.c" />
+    <ClCompile Include="Files\src\audio\SDL_mixer.c" />
+    <ClCompile Include="Files\src\audio\SDL_wave.c" />
+    <ClCompile Include="Files\src\audio\wasapi\SDL_wasapi.c" />
+    <ClCompile Include="Files\src\core\SDL_core_unsupported.c" />
+    <ClCompile Include="Files\src\core\windows\SDL_gameinput.c" />
+    <ClCompile Include="Files\src\core\windows\SDL_hid.c" />
+    <ClCompile Include="Files\src\core\windows\SDL_immdevice.c" />
+    <ClCompile Include="Files\src\core\windows\SDL_windows.c" />
+    <ClCompile Include="Files\src\core\windows\SDL_xinput.c" />
+    <ClCompile Include="Files\src\cpuinfo\SDL_cpuinfo.c" />
+    <ClCompile Include="Files\src\dialog\windows\SDL_windowsdialog.c" />
+    <ClCompile Include="Files\src\dynapi\SDL_dynapi.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_categories.c" />
+    <ClCompile Include="Files\src\events\SDL_clipboardevents.c" />
+    <ClCompile Include="Files\src\events\SDL_displayevents.c" />
+    <ClCompile Include="Files\src\events\SDL_dropevents.c" />
+    <ClCompile Include="Files\src\events\SDL_events.c" />
+    <ClCompile Include="Files\src\events\SDL_eventwatch.c" />
+    <ClCompile Include="Files\src\events\SDL_keyboard.c" />
+    <ClCompile Include="Files\src\events\SDL_keymap.c" />
+    <ClCompile Include="Files\src\events\SDL_mouse.c" />
+    <ClCompile Include="Files\src\events\SDL_pen.c" />
+    <ClCompile Include="Files\src\events\SDL_quit.c" />
+    <ClCompile Include="Files\src\events\SDL_touch.c" />
+    <ClCompile Include="Files\src\events\SDL_windowevents.c" />
+    <ClCompile Include="Files\src\io\SDL_iostream.c" />
+    <ClCompile Include="Files\src\filesystem\windows\SDL_sysfilesystem.c" />
+    <ClCompile Include="Files\src\haptic\dummy\SDL_syshaptic.c" />
+    <ClCompile Include="Files\src\haptic\SDL_haptic.c" />
+    <ClCompile Include="Files\src\haptic\windows\SDL_dinputhaptic.c" />
+    <ClCompile Include="Files\src\haptic\windows\SDL_windowshaptic.c" />
+    <ClCompile Include="Files\src\hidapi\SDL_hidapi.c" />
+    <ClCompile Include="Files\src\joystick\controller_type.c" />
+    <ClCompile Include="Files\src\joystick\dummy\SDL_sysjoystick.c" />
+    <ClCompile Include="Files\src\joystick\gdk\SDL_gameinputjoystick.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapijoystick.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_combined.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_gamecube.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_luna.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps3.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps4.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps5.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_rumble.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_shield.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_stadia.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steam.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steam_hori.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steamdeck.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_switch.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_wii.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xbox360.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xbox360w.c" />
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xboxone.c" />
+    <ClCompile Include="Files\src\joystick\SDL_gamepad.c" />
+    <ClCompile Include="Files\src\joystick\SDL_joystick.c" />
+    <ClCompile Include="Files\src\joystick\SDL_steam_virtual_gamepad.c" />
+    <ClCompile Include="Files\src\joystick\virtual\SDL_virtualjoystick.c" />
+    <ClCompile Include="Files\src\joystick\windows\SDL_dinputjoystick.c" />
+    <ClCompile Include="Files\src\joystick\windows\SDL_rawinputjoystick.c" />
+    <ClCompile Include="Files\src\joystick\windows\SDL_windowsjoystick.c" />
+    <ClCompile Include="Files\src\joystick\windows\SDL_windows_gaming_input.c" />
+    <ClCompile Include="Files\src\joystick\windows\SDL_xinputjoystick.c" />
+    <ClCompile Include="Files\src\libm\s_modf.c" />
+    <ClCompile Include="Files\src\loadso\windows\SDL_sysloadso.c" />
+    <ClCompile Include="Files\src\locale\SDL_locale.c" />
+    <ClCompile Include="Files\src\locale\windows\SDL_syslocale.c" />
+    <ClCompile Include="Files\src\misc\SDL_url.c" />
+    <ClCompile Include="Files\src\misc\windows\SDL_sysurl.c" />
+    <ClCompile Include="Files\src\power\SDL_power.c" />
+    <ClCompile Include="Files\src\power\windows\SDL_syspower.c" />
+    <ClCompile Include="Files\src\process\SDL_process.c" />
+    <ClCompile Include="Files\src\process\windows\SDL_windowsprocess.c" />
+    <ClCompile Include="Files\src\render\direct3d11\SDL_shaders_d3d11.c" />
+    <ClCompile Include="Files\src\render\direct3d12\SDL_render_d3d12.c" />
+    <ClCompile Include="Files\src\render\direct3d12\SDL_shaders_d3d12.c" />
+    <ClCompile Include="Files\src\render\direct3d\SDL_render_d3d.c" />
+    <ClCompile Include="Files\src\render\direct3d11\SDL_render_d3d11.c" />
+    <ClCompile Include="Files\src\render\direct3d\SDL_shaders_d3d.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_pipeline_gpu.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_render_gpu.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_shaders_gpu.c" />
+    <ClCompile Include="Files\src\render\opengl\SDL_render_gl.c" />
+    <ClCompile Include="Files\src\render\opengl\SDL_shaders_gl.c" />
+    <ClCompile Include="Files\src\render\opengles2\SDL_render_gles2.c" />
+    <ClCompile Include="Files\src\render\opengles2\SDL_shaders_gles2.c" />
+    <ClCompile Include="Files\src\render\SDL_d3dmath.c" />
+    <ClCompile Include="Files\src\render\SDL_render.c" />
+    <ClCompile Include="Files\src\render\SDL_render_unsupported.c" />
+    <ClCompile Include="Files\src\render\SDL_yuv_sw.c" />
+    <ClCompile Include="Files\src\render\software\SDL_blendfillrect.c" />
+    <ClCompile Include="Files\src\render\software\SDL_blendline.c" />
+    <ClCompile Include="Files\src\render\software\SDL_blendpoint.c" />
+    <ClCompile Include="Files\src\render\software\SDL_drawline.c" />
+    <ClCompile Include="Files\src\render\software\SDL_drawpoint.c" />
+    <ClCompile Include="Files\src\render\software\SDL_render_sw.c" />
+    <ClCompile Include="Files\src\render\software\SDL_rotate.c" />
+    <ClCompile Include="Files\src\render\software\SDL_triangle.c" />
+    <ClCompile Include="Files\src\SDL.c" />
+    <ClCompile Include="Files\src\SDL_assert.c" />
+    <ClCompile Include="Files\src\SDL_error.c" />
+    <ClCompile Include="Files\src\SDL_hashtable.c" />
+    <ClCompile Include="Files\src\SDL_hints.c" />
+    <ClCompile Include="Files\src\SDL_list.c" />
+    <ClCompile Include="Files\src\SDL_log.c" />
+    <ClCompile Include="Files\src\SDL_properties.c" />
+    <ClCompile Include="Files\src\SDL_utils.c" />
+    <ClCompile Include="Files\src\sensor\dummy\SDL_dummysensor.c" />
+    <ClCompile Include="Files\src\sensor\SDL_sensor.c" />
+    <ClCompile Include="Files\src\sensor\windows\SDL_windowssensor.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_crc16.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_crc32.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_getenv.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_iconv.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_malloc.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_memcpy.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_memmove.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_memset.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_mslibc.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_murmur3.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_qsort.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_random.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_stdlib.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_string.c" />
+    <ClCompile Include="Files\src\stdlib\SDL_strtokr.c" />
+    <ClCompile Include="Files\src\storage\generic\SDL_genericstorage.c" />
+    <ClCompile Include="Files\src\storage\steam\SDL_steamstorage.c" />
+    <ClCompile Include="Files\src\storage\SDL_storage.c" />
+    <ClCompile Include="Files\src\thread\generic\SDL_syscond.c" />
+    <ClCompile Include="Files\src\thread\generic\SDL_sysrwlock.c" />
+    <ClCompile Include="Files\src\thread\SDL_thread.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_syscond_cv.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_sysmutex.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_sysrwlock_srw.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_syssem.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_systhread.c" />
+    <ClCompile Include="Files\src\thread\windows\SDL_systls.c" />
+    <ClCompile Include="Files\src\timer\SDL_timer.c" />
+    <ClCompile Include="Files\src\timer\windows\SDL_systimer.c" />
+    <ClCompile Include="Files\src\time\SDL_time.c" />
+    <ClCompile Include="Files\src\time\windows\SDL_systime.c" />
+    <ClCompile Include="Files\src\tray\windows\SDL_tray.c" />
+    <ClCompile Include="Files\src\tray\SDL_tray_utils.c" />
+    <ClCompile Include="Files\src\video\dummy\SDL_nullevents.c" />
+    <ClCompile Include="Files\src\video\dummy\SDL_nullframebuffer.c" />
+    <ClCompile Include="Files\src\video\dummy\SDL_nullvideo.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenevents.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenframebuffer.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenopengles.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenvideo.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenvulkan.c" />
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenwindow.c" />
+    <ClCompile Include="Files\src\video\SDL_blit.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_0.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_1.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_A.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_auto.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_copy.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_N.c" />
+    <ClCompile Include="Files\src\video\SDL_blit_slow.c" />
+    <ClCompile Include="Files\src\video\SDL_bmp.c" />
+    <ClCompile Include="Files\src\video\SDL_clipboard.c" />
+    <ClCompile Include="Files\src\video\SDL_egl.c" />
+    <ClCompile Include="Files\src\video\SDL_fillrect.c" />
+    <ClCompile Include="Files\src\video\SDL_pixels.c" />
+    <ClCompile Include="Files\src\video\SDL_rect.c" />
+    <ClCompile Include="Files\src\video\SDL_RLEaccel.c" />
+    <ClCompile Include="Files\src\video\SDL_stb.c" />
+    <ClCompile Include="Files\src\video\SDL_stretch.c" />
+    <ClCompile Include="Files\src\video\SDL_surface.c" />
+    <ClCompile Include="Files\src\video\SDL_video.c" />
+    <ClCompile Include="Files\src\video\SDL_video_unsupported.c" />
+    <ClCompile Include="Files\src\video\SDL_vulkan_utils.c" />
+    <ClCompile Include="Files\src\video\SDL_yuv.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_surface_utils.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsclipboard.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsevents.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsframebuffer.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowskeyboard.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsgameinput.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmessagebox.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmodes.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmouse.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsopengl.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsopengles.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsrawinput.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsshape.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsvideo.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowsvulkan.c" />
+    <ClCompile Include="Files\src\video\windows\SDL_windowswindow.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_lsx.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_sse.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_std.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Files\src\core\windows\version.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ThirdParty/SDL3/SDL.vcxproj.filters
+++ b/ThirdParty/SDL3/SDL.vcxproj.filters
@@ -1,0 +1,1588 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="API Headers">
+      <UniqueIdentifier>{395b3af0-33d0-411b-b153-de1676bf1ef8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="audio">
+      <UniqueIdentifier>{5a3e3167-75be-414f-8947-a5306df372b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="atomic">
+      <UniqueIdentifier>{546d9ed1-988e-49d3-b1a5-e5b3d19de6c1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="core">
+      <UniqueIdentifier>{a56247ff-5108-4960-ba6a-6814fd1554ec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="core\windows">
+      <UniqueIdentifier>{8880dfad-2a06-4e84-ab6e-6583641ad2d1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="cpuinfo">
+      <UniqueIdentifier>{2b996a7f-f3e9-4300-a97f-2c907bcd89a9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="dynapi">
+      <UniqueIdentifier>{5713d682-2bc7-4da4-bcf0-262a98f142eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="events">
+      <UniqueIdentifier>{5e27e19f-b3f8-4e2d-b323-b00b2040ec86}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="io">
+      <UniqueIdentifier>{a3ab9cff-8495-4a5c-8af6-27e43199a712}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="filesystem">
+      <UniqueIdentifier>{377061e4-3856-4f05-b916-0d3b360df0f6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="filesystem\windows">
+      <UniqueIdentifier>{226a6643-1c65-4c7f-92aa-861313d974bb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="haptic">
+      <UniqueIdentifier>{ef859522-a7fe-4a00-a511-d6a9896adf5b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hidapi">
+      <UniqueIdentifier>{01fd2642-4493-4316-b548-fb829f4c9125}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick">
+      <UniqueIdentifier>{cce7558f-590a-4f0a-ac0d-e579f76e588e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libm">
+      <UniqueIdentifier>{7a53c9e4-d4bd-40ed-9265-1625df685121}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hidapi\hidapi">
+      <UniqueIdentifier>{4c7a051c-ce7c-426c-bf8c-9187827f9052}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="loadso">
+      <UniqueIdentifier>{97e2f79f-311b-42ea-81b2-e801649fdd93}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="loadso\windows">
+      <UniqueIdentifier>{baf97c8c-7e90-41e5-bff8-14051b8d3956}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="locale">
+      <UniqueIdentifier>{45e50d3a-56c9-4352-b811-0c60c49a2431}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="misc">
+      <UniqueIdentifier>{9d86e0ef-d6f6-4db2-bfc5-b3529406fa8d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="misc\windows">
+      <UniqueIdentifier>{b35fa13c-6ed2-4680-8c56-c7d71b76ceab}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="locale\windows">
+      <UniqueIdentifier>{61b61b31-9e26-4171-a3bb-b969f1889726}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="audio\directsound">
+      <UniqueIdentifier>{f63aa216-6ee7-4143-90d3-32be3787f276}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="audio\disk">
+      <UniqueIdentifier>{90bee923-89df-417f-a6c3-3e260a7dd54d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="audio\dummy">
+      <UniqueIdentifier>{4c8ad943-c2fb-4014-9ca3-041e0ad08426}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="audio\wasapi">
+      <UniqueIdentifier>{3d68ae70-a9ff-46cf-be69-069f0b02aca0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="haptic\windows">
+      <UniqueIdentifier>{ebc2fca3-3c26-45e3-815e-3e0581d5e226}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="haptic\dummy">
+      <UniqueIdentifier>{47c445a2-7014-4e15-9660-7c89a27dddcf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick\dummy">
+      <UniqueIdentifier>{d008487d-6ed0-4251-848b-79a68e3c1459}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick\gdk">
+      <UniqueIdentifier>{c9e8273e-13ae-47dc-bef8-8ad8e64c9a3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick\hidapi">
+      <UniqueIdentifier>{c9e8273e-13ae-47dc-bef8-8ad8e64c9a3d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick\windows">
+      <UniqueIdentifier>{0b8e136d-56ae-47e7-9981-e863a57ac616}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="joystick\virtual">
+      <UniqueIdentifier>{bf3febd3-9328-43e8-b196-0fd3be8177dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video">
+      <UniqueIdentifier>{1a62dc68-52d2-4c07-9d81-d94dfe1d0d12}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\dummy">
+      <UniqueIdentifier>{e9f01b22-34b3-4380-ade6-0e96c74e9c90}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\yuv2rgb">
+      <UniqueIdentifier>{f674f22f-7841-4f3a-974e-c36b2d4823fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\windows">
+      <UniqueIdentifier>{d7ad92de-4e55-4202-9b2b-1bd9a35fe4dc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="timer">
+      <UniqueIdentifier>{8311d79d-9ad5-4369-99fe-b2fb2659d402}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="timer\windows">
+      <UniqueIdentifier>{6c4dfb80-fdf9-497c-a6ff-3cd8f22efde9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="thread">
+      <UniqueIdentifier>{4810e35c-33cb-4da2-bfaf-452da20d3c9a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="thread\windows">
+      <UniqueIdentifier>{2cf93f1d-81fd-4bdc-998c-5e2fa43988bc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="thread\generic">
+      <UniqueIdentifier>{5752b7ab-2344-4f38-95ab-b5d3bc150315}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="stdlib">
+      <UniqueIdentifier>{7a0eae3d-f113-4914-b926-6816d1929250}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sensor">
+      <UniqueIdentifier>{ee602cbf-96a2-4b0b-92a9-51d38a727411}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sensor\dummy">
+      <UniqueIdentifier>{a812185b-9060-4a1c-8431-be4f66894626}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sensor\windows">
+      <UniqueIdentifier>{31c16cdf-adc4-4950-8293-28ba530f3882}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render">
+      <UniqueIdentifier>{add61b53-8144-47d6-bd67-3420a87c4905}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\direct3d">
+      <UniqueIdentifier>{e7cdcf36-b462-49c7-98b7-07ea7b3687f4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\direct3d11">
+      <UniqueIdentifier>{82588eef-dcaa-4f69-b2a9-e675940ce54c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\opengl">
+      <UniqueIdentifier>{560239c3-8fa1-4d23-a81a-b8408b2f7d3f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\opengles2">
+      <UniqueIdentifier>{81711059-7575-4ece-9e68-333b63e992c4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\software">
+      <UniqueIdentifier>{1e44970f-7535-4bfb-b8a5-ea0cea0349e0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="power">
+      <UniqueIdentifier>{1dd91224-1176-492b-a2cb-e26153394db0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="power\windows">
+      <UniqueIdentifier>{e3ecfe50-cf22-41d3-8983-2fead5164b47}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\khronos">
+      <UniqueIdentifier>{5521d22f-1e52-47a6-8c52-06a3b6bdefd7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\khronos\vulkan">
+      <UniqueIdentifier>{4755f3a6-49ac-46d6-86be-21f5c21f2197}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\direct3d12">
+      <UniqueIdentifier>{f48c2b17-1bee-4fec-a7c8-24cf619abe08}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\intrin">
+      <UniqueIdentifier>{653672cc-90ae-4eba-a256-6479f2c31804}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{00001967ea2801028a046a722a070000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\generic">
+      <UniqueIdentifier>{0000ddc7911820dbe64274d3654f0000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="camera">
+      <UniqueIdentifier>{0000de1b75e1a954834693f1c81e0000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="camera\dummy">
+      <UniqueIdentifier>{0000fc2700d453b3c8d79fe81e1c0000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="camera\mediafoundation">
+      <UniqueIdentifier>{0000fbfe2d21e4f451142e7d0e870000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="render\vulkan">
+      <UniqueIdentifier>{5115ba31-20f8-4eab-a8c5-6a572ab78ff7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="time">
+      <UniqueIdentifier>{00003288226ff86b99eee5b443e90000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="time\windows">
+      <UniqueIdentifier>{0000d7fda065b13b0ca4ab262c380000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="gpu">
+      <UniqueIdentifier>{098fbef9-d8a0-4b3b-b57b-d157d395335d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="dialog">
+      <UniqueIdentifier>{00008dfdfa0190856fbf3c7db52d0000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="video\offscreen">
+      <UniqueIdentifier>{748cf015-00b8-4e71-ac48-02e947e4d93d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\windows">
+      <UniqueIdentifier>{00009d5ded166cc6c6680ec771a30000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="io\generic">
+      <UniqueIdentifier>{00004d6806b6238cae0ed62db5440000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="io\windows">
+      <UniqueIdentifier>{000028b2ea36d7190d13777a4dc70000}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Files\include\SDL3\SDL_begin_code.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_camera.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_close_code.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_assert.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_atomic.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_audio.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_bits.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_blendmode.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_clipboard.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_copying.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_cpuinfo.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_egl.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_endian.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_error.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_events.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_filesystem.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_gamepad.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_guid.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_haptic.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_hints.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_hidapi.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_asyncio.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_joystick.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_keyboard.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_keycode.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_loadso.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_locale.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_log.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_main.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_messagebox.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_mouse.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_mutex.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengl.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengl_glext.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2ext.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_gl2platform.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_opengles2_khrplatform.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_pen.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_pixels.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_platform.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_platform_defines.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_power.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_process.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_properties.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_rect.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_render.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_revision.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_iostream.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_scancode.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_sensor.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_stdinc.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_surface.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_system.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_assert.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_common.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_compare.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_crc32.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_font.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_fuzzer.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_harness.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_log.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_md5.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_thread.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_timer.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_touch.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_version.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_video.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_vulkan.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\camera\SDL_camera_c.h">
+      <Filter>camera</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\camera\SDL_syscamera.h">
+      <Filter>camera</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\filesystem\SDL_sysfilesystem.h">
+      <Filter>filesystem</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\io\SDL_asyncio_c.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\io\SDL_sysasyncio.h">
+      <Filter>io</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\main\SDL_main_callbacks.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\SDL_error_c.h" />
+    <ClInclude Include="Files\src\SDL_hashtable.h" />
+    <ClInclude Include="Files\src\SDL_list.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_metal.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_misc.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_test_memory.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_audio_c.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_audiodev_c.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_wave.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_sysaudio.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_audioqueue.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\SDL_audioresample.h">
+      <Filter>audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_directx.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_gameinput.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_hid.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_immdevice.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_windows.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_xinput.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\core\windows\SDL_directx.h">
+      <Filter>core\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\cpuinfo\SDL_cpuinfo_c.h">
+      <Filter>cpuinfo</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi.h">
+      <Filter>dynapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_overrides.h">
+      <Filter>dynapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_procs.h">
+      <Filter>dynapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\dynapi\SDL_dynapi_unsupported.h">
+      <Filter>dynapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_clipboardevents_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_displayevents_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_dropevents_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_events_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_keyboard_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_keymap_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_mouse_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_touch_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\SDL_windowevents_c.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\blank_cursor.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\default_cursor.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\events\scancodes_windows.h">
+      <Filter>events</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\haptic\SDL_syshaptic.h">
+      <Filter>haptic</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\haptic\SDL_haptic_c.h">
+      <Filter>haptic</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\SDL_gamepad_c.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\SDL_gamepad_db.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\SDL_joystick_c.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\SDL_steam_virtual_gamepad.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\SDL_sysjoystick.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\controller_type.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\usb_ids.h">
+      <Filter>joystick</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\libm\math_libm.h">
+      <Filter>libm</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\libm\math_private.h">
+      <Filter>libm</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\hidapi\hidapi\hidapi.h">
+      <Filter>hidapi\hidapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\locale\SDL_syslocale.h">
+      <Filter>locale</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\misc\SDL_sysurl.h">
+      <Filter>misc</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\directsound\SDL_directsound.h">
+      <Filter>audio\directsound</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\disk\SDL_diskaudio.h">
+      <Filter>audio\disk</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\dummy\SDL_dummyaudio.h">
+      <Filter>audio\dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\audio\wasapi\SDL_wasapi.h">
+      <Filter>audio\wasapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\haptic\windows\SDL_dinputhaptic_c.h">
+      <Filter>haptic\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\haptic\windows\SDL_windowshaptic_c.h">
+      <Filter>haptic\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\hidapi\SDL_hidapijoystick_c.h">
+      <Filter>joystick\hidapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\hidapi\SDL_hidapi_rumble.h">
+      <Filter>joystick\hidapi</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\windows\SDL_dinputjoystick_c.h">
+      <Filter>joystick\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\windows\SDL_rawinputjoystick_c.h">
+      <Filter>joystick\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\windows\SDL_windowsjoystick_c.h">
+      <Filter>joystick\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\windows\SDL_xinputjoystick_c.h">
+      <Filter>joystick\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\joystick\virtual\SDL_virtualjoystick_c.h">
+      <Filter>joystick\virtual</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_RLEaccel_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_surface_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_blit.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_blit_auto.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_blit_copy.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_blit_slow.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_clipboard_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_pixels_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_rect_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_sysvideo.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_egl_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_stb_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_yuv_c.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\SDL_vulkan_internal.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\dummy\SDL_nullevents_c.h">
+      <Filter>video\dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\dummy\SDL_nullframebuffer_c.h">
+      <Filter>video\dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\dummy\SDL_nullvideo.h">
+      <Filter>video\dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb.h">
+      <Filter>video\yuv2rgb</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_sse_func.h">
+      <Filter>video\yuv2rgb</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_std_func.h">
+      <Filter>video\yuv2rgb</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_surface_utils.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsclipboard.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsevents.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsframebuffer.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowskeyboard.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsgameinput.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmessagebox.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmodes.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsmouse.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsopengl.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsrawinput.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsshape.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsvideo.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsvulkan.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowswindow.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\wmmsg.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_msctf.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\windows\SDL_windowsopengles.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\timer\SDL_timer_c.h">
+      <Filter>timer</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\thread\SDL_thread_c.h">
+      <Filter>thread</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\thread\SDL_systhread.h">
+      <Filter>thread</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\thread\windows\SDL_sysmutex_c.h">
+      <Filter>thread\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\thread\windows\SDL_systhread_c.h">
+      <Filter>thread\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\thread\generic\SDL_syscond_c.h">
+      <Filter>thread\generic</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\sensor\SDL_sensor_c.h">
+      <Filter>sensor</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\sensor\SDL_syssensor.h">
+      <Filter>sensor</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\sensor\dummy\SDL_dummysensor.h">
+      <Filter>sensor\dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\sensor\windows\SDL_windowssensor.h">
+      <Filter>sensor\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\SDL_d3dmath.h">
+      <Filter>render</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\SDL_sysrender.h">
+      <Filter>render</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\SDL_yuv_sw_c.h">
+      <Filter>render</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\direct3d\SDL_shaders_d3d.h">
+      <Filter>render\direct3d</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\direct3d11\SDL_shaders_d3d11.h">
+      <Filter>render\direct3d11</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\opengl\SDL_glfuncs.h">
+      <Filter>render\opengl</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\opengl\SDL_shaders_gl.h">
+      <Filter>render\opengl</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\opengles2\SDL_shaders_gles2.h">
+      <Filter>render\opengles2</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\opengles2\SDL_gles2funcs.h">
+      <Filter>render\opengles2</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_blendfillrect.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_blendline.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_blendpoint.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_draw.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_drawline.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_drawpoint.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_render_sw_c.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_rotate.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\render\software\SDL_triangle.h">
+      <Filter>render\software</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\power\SDL_syspower.h">
+      <Filter>power</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xlib_xrandr.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_icd.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_layer.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_platform.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vk_sdk_platform.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_android.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_beta.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_core.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_directfb.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_fuchsia.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_ggp.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_ios.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_macos.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_metal.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_vi.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_wayland.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_win32.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xcb.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\khronos\vulkan\vulkan_xlib.h">
+      <Filter>video\khronos\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\SDL_assert_c.h" />
+    <ClInclude Include="Files\src\SDL_hints_c.h" />
+    <ClInclude Include="Files\src\SDL_internal.h" />
+    <ClInclude Include="Files\src\SDL_log_c.h" />
+    <ClInclude Include="Files\src\SDL_properties_c.h" />
+    <ClInclude Include="Files\src\render\direct3d12\SDL_shaders_d3d12.h">
+      <Filter>render\direct3d12</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\hidapi\SDL_hidapi_c.h" />
+    <ClInclude Include="Files\src\thread\generic\SDL_sysrwlock_c.h" />
+    <ClInclude Include="Files\src\thread\generic\SDL_sysrwlock_c.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_common.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_internal.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_lsx.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_lsx_func.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_sse.h" />
+    <ClInclude Include="Files\src\video\yuv2rgb\yuv_rgb_std.h" />
+    <ClInclude Include="Files\src\render\vulkan\SDL_shaders_vulkan.h">
+      <Filter>render\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenevents_c.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenframebuffer_c.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenopengles.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenvideo.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenvulkan.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\video\offscreen\SDL_offscreenwindow.h">
+      <Filter>video\offscreen</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_gpu.h">
+      <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\gpu\SDL_sysgpu.h">
+      <Filter>gpu</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\src\gpu\vulkan\SDL_gpu_vulkan_vkfuncs.h">
+      <Filter>gpu</Filter>
+    </ClInclude>
+    <ClInclude Include="Files\include\SDL3\SDL_storage.h" />
+    <ClInclude Include="Files\include\SDL3\SDL_time.h" />
+    <ClInclude Include="Files\src\events\SDL_categories_c.h" />
+    <ClInclude Include="Files\src\events\SDL_eventwatch_c.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Files\src\audio\wasapi\SDL_wasapi.c" />
+    <ClCompile Include="Files\src\camera\dummy\SDL_camera_dummy.c">
+      <Filter>camera\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\camera\mediafoundation\SDL_camera_mediafoundation.c">
+      <Filter>camera\mediafoundation</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\camera\SDL_camera.c">
+      <Filter>camera</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\dialog\SDL_dialog.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\dialog\SDL_dialog_utils.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\filesystem\SDL_filesystem.c">
+      <Filter>filesystem</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\filesystem\windows\SDL_sysfsops.c">
+      <Filter>filesystem\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\io\generic\SDL_asyncio_generic.c">
+      <Filter>io\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\io\SDL_asyncio.c">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\io\windows\SDL_asyncio_windows_ioring.c">
+      <Filter>io\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\main\generic\SDL_sysmain_callbacks.c">
+      <Filter>main\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\main\SDL_main_callbacks.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\main\SDL_runapp.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\main\windows\SDL_sysmain_runapp.c">
+      <Filter>main\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\SDL.c" />
+    <ClCompile Include="Files\src\SDL_assert.c" />
+    <ClCompile Include="Files\src\SDL_error.c" />
+    <ClCompile Include="Files\src\SDL_guid.c" />
+    <ClCompile Include="Files\src\SDL_hashtable.c" />
+    <ClCompile Include="Files\src\SDL_hints.c" />
+    <ClCompile Include="Files\src\SDL_list.c" />
+    <ClCompile Include="Files\src\SDL_properties.c" />
+    <ClCompile Include="Files\src\SDL_utils.c" />
+    <ClCompile Include="Files\src\audio\SDL_audio.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_audiocvt.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_audiodev.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_audiotypecvt.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_audioqueue.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_audioresample.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_wave.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\SDL_mixer.c">
+      <Filter>audio</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\atomic\SDL_atomic.c">
+      <Filter>atomic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\atomic\SDL_spinlock.c">
+      <Filter>atomic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\SDL_core_unsupported.c">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\SDL_gameinput.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\SDL_hid.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\SDL_immdevice.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\SDL_windows.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\SDL_xinput.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\cpuinfo\SDL_cpuinfo.c">
+      <Filter>cpuinfo</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\dialog\windows\SDL_windowsdialog.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\dynapi\SDL_dynapi.c">
+      <Filter>dynapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_categories.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_clipboardevents.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_displayevents.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_dropevents.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_events.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_keyboard.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_keymap.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_mouse.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_pen.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_quit.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_touch.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\events\SDL_windowevents.c">
+      <Filter>events</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\io\SDL_iostream.c">
+      <Filter>io</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\filesystem\windows\SDL_sysfilesystem.c">
+      <Filter>filesystem\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\haptic\SDL_haptic.c">
+      <Filter>haptic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\hidapi\SDL_hidapi.c">
+      <Filter>hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\controller_type.c">
+      <Filter>joystick</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\SDL_gamepad.c">
+      <Filter>joystick</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\SDL_joystick.c">
+      <Filter>joystick</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\SDL_steam_virtual_gamepad.c">
+      <Filter>joystick</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\libm\s_modf.c">
+      <Filter>libm</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\loadso\windows\SDL_sysloadso.c">
+      <Filter>loadso\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\misc\SDL_url.c">
+      <Filter>misc</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\misc\windows\SDL_sysurl.c">
+      <Filter>misc\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\locale\windows\SDL_syslocale.c">
+      <Filter>locale\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\locale\SDL_locale.c">
+      <Filter>locale</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\directsound\SDL_directsound.c">
+      <Filter>audio\directsound</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\disk\SDL_diskaudio.c">
+      <Filter>audio\disk</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\dummy\SDL_dummyaudio.c">
+      <Filter>audio\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\audio\wasapi\SDL_wasapi.c">
+      <Filter>audio\wasapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\haptic\windows\SDL_dinputhaptic.c">
+      <Filter>haptic\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\haptic\windows\SDL_windowshaptic.c">
+      <Filter>haptic\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\haptic\dummy\SDL_syshaptic.c">
+      <Filter>haptic\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\dummy\SDL_sysjoystick.c">
+      <Filter>joystick\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\gdk\SDL_gameinputjoystick.c">
+      <Filter>joystick\gdk</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_combined.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_gamecube.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_luna.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps3.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps4.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_ps5.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_rumble.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_shield.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_stadia.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steam.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steam_hori.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_steamdeck.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_switch.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_wii.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xbox360.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xbox360w.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapi_xboxone.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\hidapi\SDL_hidapijoystick.c">
+      <Filter>joystick\hidapi</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\windows\SDL_dinputjoystick.c">
+      <Filter>joystick\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\windows\SDL_rawinputjoystick.c">
+      <Filter>joystick\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\windows\SDL_windows_gaming_input.c">
+      <Filter>joystick\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\windows\SDL_windowsjoystick.c">
+      <Filter>joystick\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\windows\SDL_xinputjoystick.c">
+      <Filter>joystick\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\joystick\virtual\SDL_virtualjoystick.c">
+      <Filter>joystick\virtual</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\time\SDL_time.c">
+      <Filter>time</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\time\windows\SDL_systime.c">
+      <Filter>time\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\tray\windows\SDL_tray.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\tray\SDL_tray_utils.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_RLEaccel.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_0.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_1.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_A.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_N.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_auto.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_copy.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_blit_slow.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_bmp.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_clipboard.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_egl.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_fillrect.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_pixels.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_rect.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_stb.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_stretch.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_surface.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_video.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_video_unsupported.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_yuv.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\SDL_vulkan_utils.c">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\dummy\SDL_nullevents.c">
+      <Filter>video\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\dummy\SDL_nullframebuffer.c">
+      <Filter>video\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\dummy\SDL_nullvideo.c">
+      <Filter>video\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_surface_utils.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsclipboard.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsevents.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsframebuffer.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowskeyboard.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsgameinput.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmessagebox.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmodes.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsmouse.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsopengl.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsopengles.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsrawinput.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsshape.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsvideo.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowsvulkan.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\windows\SDL_windowswindow.c">
+      <Filter>video\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\timer\SDL_timer.c">
+      <Filter>timer</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\timer\windows\SDL_systimer.c">
+      <Filter>timer\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\SDL_thread.c">
+      <Filter>thread</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_syscond_cv.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_sysmutex.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_sysrwlock_srw.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_syssem.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_systhread.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\windows\SDL_systls.c">
+      <Filter>thread\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\generic\SDL_syscond.c">
+      <Filter>thread\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_crc16.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_crc32.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_getenv.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_iconv.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_malloc.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_memcpy.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_memmove.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_memset.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_murmur3.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_qsort.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_random.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_stdlib.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_string.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_strtokr.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\sensor\SDL_sensor.c">
+      <Filter>sensor</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\sensor\dummy\SDL_dummysensor.c">
+      <Filter>sensor\dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\sensor\windows\SDL_windowssensor.c">
+      <Filter>sensor\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\SDL_d3dmath.c">
+      <Filter>render</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\SDL_render.c">
+      <Filter>render</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\SDL_render_unsupported.c">
+      <Filter>render</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\SDL_yuv_sw.c">
+      <Filter>render</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\direct3d\SDL_render_d3d.c">
+      <Filter>render\direct3d</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\direct3d\SDL_shaders_d3d.c">
+      <Filter>render\direct3d</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\direct3d11\SDL_render_d3d11.c">
+      <Filter>render\direct3d11</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\direct3d11\SDL_shaders_d3d11.c">
+      <Filter>render\direct3d11</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\opengl\SDL_render_gl.c">
+      <Filter>render\opengl</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\opengl\SDL_shaders_gl.c">
+      <Filter>render\opengl</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\opengles2\SDL_render_gles2.c">
+      <Filter>render\opengles2</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\opengles2\SDL_shaders_gles2.c">
+      <Filter>render\opengles2</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_blendfillrect.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_blendline.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_blendpoint.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_drawline.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_drawpoint.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_render_sw.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_rotate.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\software\SDL_triangle.c">
+      <Filter>render\software</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\power\SDL_power.c">
+      <Filter>power</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\power\windows\SDL_syspower.c">
+      <Filter>power\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\SDL_log.c" />
+    <ClCompile Include="Files\src\render\direct3d12\SDL_render_d3d12.c">
+      <Filter>render\direct3d12</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\direct3d12\SDL_shaders_d3d12.c">
+      <Filter>render\direct3d12</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\core\windows\pch.c">
+      <Filter>core\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\stdlib\SDL_mslibc.c">
+      <Filter>stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\thread\generic\SDL_sysrwlock.c" />
+    <ClCompile Include="Files\src\thread\generic\SDL_sysrwlock.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_lsx.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_sse.c" />
+    <ClCompile Include="Files\src\video\yuv2rgb\yuv_rgb_std.c" />
+    <ClCompile Include="Files\src\render\vulkan\SDL_render_vulkan.c">
+      <Filter>render\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\render\vulkan\SDL_shaders_vulkan.c">
+      <Filter>render\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenevents.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenframebuffer.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenopengles.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenvideo.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenvulkan.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\video\offscreen\SDL_offscreenwindow.c">
+      <Filter>video\offscreen</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\gpu\SDL_gpu.c">
+      <Filter>gpu</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\gpu\d3d12\SDL_gpu_d3d12.c">
+      <Filter>gpu</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\gpu\vulkan\SDL_gpu_vulkan.c">
+      <Filter>gpu</Filter>
+    </ClCompile>
+    <ClCompile Include="Files\src\process\SDL_process.c" />
+    <ClCompile Include="Files\src\process\windows\SDL_windowsprocess.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_pipeline_gpu.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_render_gpu.c" />
+    <ClCompile Include="Files\src\render\gpu\SDL_shaders_gpu.c" />
+    <ClCompile Include="Files\src\storage\generic\SDL_genericstorage.c" />
+    <ClCompile Include="Files\src\storage\steam\SDL_steamstorage.c" />
+    <ClCompile Include="Files\src\storage\SDL_storage.c" />
+    <ClCompile Include="Files\src\events\SDL_eventwatch.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Files\src\core\windows\version.rc" />
+  </ItemGroup>
+</Project>

--- a/ThirdParty/ThirdParty.SDL3.props
+++ b/ThirdParty/ThirdParty.SDL3.props
@@ -2,7 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup Condition="$(ThirdPartyDeps.Contains('SDL3'))">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)SDL3\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)SDL3\Files\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>setupapi.lib;winmm.lib;imm32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/ThirdParty/ThirdParty.SDL3.props
+++ b/ThirdParty/ThirdParty.SDL3.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup Condition="$(ThirdPartyDeps.Contains('SDL3'))">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)SDL3\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/WinMM.vcxproj
+++ b/WinMM.vcxproj
@@ -97,6 +97,9 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
+    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+      <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <MASM Include="Source\ForwardedApiWinMM.asm" />

--- a/WinMM.vcxproj
+++ b/WinMM.vcxproj
@@ -97,7 +97,7 @@
     <ProjectReference Include="Modules\Infra\CoreInfra.vcxproj">
       <Project>{5af31c51-1646-4bda-9407-12273b2da870}</Project>
     </ProjectReference>
-    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+    <ProjectReference Include="ThirdParty\SDL3\SDL.vcxproj">
       <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/Xidi.sln
+++ b/Xidi.sln
@@ -19,6 +19,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CoreInfra", "Modules\Infra\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestInfra", "Modules\Infra\TestInfra.vcxproj", "{6ABF224B-C252-4876-B2E1-8CA88E93610A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL3", "ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -83,6 +85,14 @@ Global
 		{6ABF224B-C252-4876-B2E1-8CA88E93610A}.Release|Win32.Build.0 = Release|Win32
 		{6ABF224B-C252-4876-B2E1-8CA88E93610A}.Release|x64.ActiveCfg = Release|x64
 		{6ABF224B-C252-4876-B2E1-8CA88E93610A}.Release|x64.Build.0 = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +100,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5AF31C51-1646-4BDA-9407-12273B2DA870} = {314218EC-8403-44F6-B02F-4493E59C2BE0}
 		{6ABF224B-C252-4876-B2E1-8CA88E93610A} = {314218EC-8403-44F6-B02F-4493E59C2BE0}
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68} = {314218EC-8403-44F6-B02F-4493E59C2BE0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6806A1BD-FB15-41EB-97A5-C74B7EAE21DA}

--- a/Xidi.sln
+++ b/Xidi.sln
@@ -22,7 +22,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CoreInfra", "Modules\Infra\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestInfra", "Modules\Infra\TestInfra.vcxproj", "{6ABF224B-C252-4876-B2E1-8CA88E93610A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL3", "ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL3", "ThirdParty\SDL3\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Xidi.sln
+++ b/Xidi.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XidiTest", "XidiTest.vcxproj", "{90878664-D123-48A3-8101-3A2099DB0AB1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68} = {81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DInput", "DInput.vcxproj", "{34FEDC3E-3FE8-43D0-9BDE-1A15332D8C41}"
 EndProject

--- a/XidiTest.vcxproj
+++ b/XidiTest.vcxproj
@@ -213,6 +213,9 @@
     <ProjectReference Include="Modules\Infra\TestInfra.vcxproj">
       <Project>{6abf224b-c252-4876-b2e1-8ca88e93610a}</Project>
     </ProjectReference>
+    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+      <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/XidiTest.vcxproj
+++ b/XidiTest.vcxproj
@@ -213,7 +213,7 @@
     <ProjectReference Include="Modules\Infra\TestInfra.vcxproj">
       <Project>{6abf224b-c252-4876-b2e1-8ca88e93610a}</Project>
     </ProjectReference>
-    <ProjectReference Include="ThirdParty\SDL3\VisualC\SDL\SDL.vcxproj">
+    <ProjectReference Include="ThirdParty\SDL3\SDL.vcxproj">
       <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
First off, I know this is a very large change, essentially changing Xidi from a XInput->DInput converter to an SDL3->DInput converter . I completely understand if you do not want to merge this; I would continue working on the fork in my own time if so.

That being said, converting from the SDL3 gamepad API has many benefits, only some of which are implemented in this PR. The main one being support for many, many more controllers, both old and new. This allows people with non-XInput controllers to still be able to take advantage of Xidi's versatile mapping capabilities which are often invaluable with older games with fixed, nonflexible mappings.

Potentially, this could also allow for more buttons to be mapped (SDL3 supports "Misc" buttons for gamepads with extra ones that don't have a given use), more than 4 controllers to be used, better rumble support (such as impulse triggers) and perhaps eventually (with a lot of work) remapping of keyboard/mouse as well.

Currently I would consider this PR to be a WIP; a lot of the documentation and variable/function names still reference XInput, and ideally it would be great to actually support outputting to XInput with this as well.